### PR TITLE
Enable stricter mypy checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,5 +31,5 @@ basepython=python
 extras=lint
 commands=
     flake8 {toxinidir}/py_snappy {toxinidir}/tests
-	  mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p py_snappy
+	  mypy --follow-imports=silent --ignore-missing-imports --strict -p py_snappy
 	  black --check --diff {toxinidir}/py_snappy/ --check --diff {toxinidir}/tests/


### PR DESCRIPTION
## What was wrong?

Not all mypy checks where enabled. It's much easier to be strict right from the start compared to trying to refactor into more strictness later on.

## How was it fixed?

Use `--strict` (same as we use in `lahja` library). That includes:

```
  --strict                  Strict mode. Enables the following flags:
                            --disallow-untyped-calls, --disallow-untyped-defs,
                            --disallow-incomplete-defs, --check-untyped-defs,
                            --disallow-subclassing-any, --disallow-untyped-
                            decorators, --warn-redundant-casts, --warn-return-
                            any, --warn-unused-ignores, --warn-unused-configs,
                            --no-implicit-optional
```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/08/animal-wildlife-photography-marina-cano-17.jpg)
