### PR TITLE
Add error case testing and empty bytestring tests

### DIFF
--- a/py_snappy/__init__.py
+++ b/py_snappy/__init__.py
@@ -1,1 +1,2 @@
+from .exceptions import BaseSnappyError, CorruptError, TooLargeError  # noqa: F401
 from .main import compress, decompress  # noqa: F401

--- a/tests/core/test_empty_bytestring.py
+++ b/tests/core/test_empty_bytestring.py
@@ -1,0 +1,12 @@
+import pytest
+
+from py_snappy import compress, decompress, CorruptError
+
+
+def test_compress_empty_string():
+    assert compress(b'') == b'\x00'
+
+
+def test_decompress_empty_string():
+    with pytest.raises(CorruptError):
+        decompress(b'')

--- a/tests/core/test_empty_bytestring.py
+++ b/tests/core/test_empty_bytestring.py
@@ -4,9 +4,9 @@ from py_snappy import compress, decompress, CorruptError
 
 
 def test_compress_empty_string():
-    assert compress(b'') == b'\x00'
+    assert compress(b"") == b"\x00"
 
 
 def test_decompress_empty_string():
     with pytest.raises(CorruptError):
-        decompress(b'')
+        decompress(b"")

--- a/tests/core/test_libsnappy_compat.py
+++ b/tests/core/test_libsnappy_compat.py
@@ -1,12 +1,7 @@
 from hypothesis import given, settings, strategies as st
 
 from py_snappy import compress, decompress, BaseSnappyError
-from snappy import (
-    compress as libsnappy_compress,
-    decompress as libsnappy_decompress,
-    UncompressError,
-)
-
+from snappy import compress as libsnappy_compress, decompress as libsnappy_decompress, UncompressError
 try:
     from snappy._snappy import CompressedLengthError
 except ImportError:
@@ -35,15 +30,18 @@ def test_libsnappy_decompress_local_compressed(value):
     assert value == result
 
 
-LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError)
+LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError,)
 PY_SNAPPY_ERRORS = (BaseSnappyError,)
 
 
 #
 # Error cases
 #
-@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
-@settings(max_examples=1000, deadline=None)  # takes a long time.
+@given(value=st.binary(min_size=1, max_size=MEGABYTE // 2))
+@settings(
+    max_examples=1000,
+    deadline=1000,  # takes a long time.
+)
 def test_decompress_error_parity(value):
     try:
         py_result = decompress(value)

--- a/tests/core/test_libsnappy_compat.py
+++ b/tests/core/test_libsnappy_compat.py
@@ -14,7 +14,7 @@ MEGABYTE = 1000000
 #
 # Round trip value -> compress() -> decompress()
 #
-@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
 @settings(max_examples=1000)
 def test_local_decompress_libsnappy_compressed(value):
     intermediate = libsnappy_compress(value)
@@ -22,7 +22,7 @@ def test_local_decompress_libsnappy_compressed(value):
     assert value == result
 
 
-@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
 @settings(max_examples=1000)
 def test_libsnappy_decompress_local_compressed(value):
     intermediate = compress(value)
@@ -37,7 +37,7 @@ PY_SNAPPY_ERRORS = (BaseSnappyError,)
 #
 # Error cases
 #
-@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
 @settings(
     max_examples=1000,
     deadline=None,  # takes a long time.

--- a/tests/core/test_libsnappy_compat.py
+++ b/tests/core/test_libsnappy_compat.py
@@ -1,12 +1,20 @@
 from hypothesis import given, settings, strategies as st
 
-from py_snappy import compress, decompress
-from snappy import compress as libsnappy_compress, decompress as libsnappy_decompress
+from py_snappy import compress, decompress, BaseSnappyError
+from snappy import compress as libsnappy_compress, decompress as libsnappy_decompress, UncompressError
+try:
+    from snappy._snappy import CompressedLengthError
+except ImportError:
+    CompressedLengthError = None
+
 
 MEGABYTE = 1000000
 
 
-@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
+#
+# Round trip value -> compress() -> decompress()
+#
+@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
 @settings(max_examples=1000)
 def test_local_decompress_libsnappy_compressed(value):
     intermediate = libsnappy_compress(value)
@@ -14,9 +22,42 @@ def test_local_decompress_libsnappy_compressed(value):
     assert value == result
 
 
-@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
+@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
 @settings(max_examples=1000)
 def test_libsnappy_decompress_local_compressed(value):
     intermediate = compress(value)
     result = libsnappy_decompress(intermediate)
     assert value == result
+
+
+LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError,)
+PY_SNAPPY_ERRORS = (BaseSnappyError,)
+
+
+#
+# Error cases
+#
+@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@settings(
+    max_examples=1000,
+    deadline=None,  # takes a long time.
+)
+def test_decompress_error_parity(value):
+    try:
+        py_result = decompress(value)
+    except PY_SNAPPY_ERRORS:
+        py_snappy_error = True
+    else:
+        py_snappy_error = False
+
+    try:
+        lib_result = libsnappy_decompress(value)
+    except LIB_SNAPPY_ERRORS:
+        lib_snappy_error = True
+    else:
+        lib_snappy_error = False
+
+    if py_snappy_error and lib_snappy_error:
+        pass
+    if not py_snappy_error and not lib_snappy_error:
+        assert lib_result == py_result

--- a/tests/core/test_libsnappy_compat.py
+++ b/tests/core/test_libsnappy_compat.py
@@ -1,7 +1,12 @@
 from hypothesis import given, settings, strategies as st
 
 from py_snappy import compress, decompress, BaseSnappyError
-from snappy import compress as libsnappy_compress, decompress as libsnappy_decompress, UncompressError
+from snappy import (
+    compress as libsnappy_compress,
+    decompress as libsnappy_decompress,
+    UncompressError,
+)
+
 try:
     from snappy._snappy import CompressedLengthError
 except ImportError:
@@ -30,7 +35,7 @@ def test_libsnappy_decompress_local_compressed(value):
     assert value == result
 
 
-LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError,)
+LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError)
 PY_SNAPPY_ERRORS = (BaseSnappyError,)
 
 
@@ -38,10 +43,7 @@ PY_SNAPPY_ERRORS = (BaseSnappyError,)
 # Error cases
 #
 @given(value=st.binary(min_size=1, max_size=MEGABYTE // 2))
-@settings(
-    max_examples=1000,
-    deadline=1000,  # takes a long time.
-)
+@settings(max_examples=400, deadline=None)  # takes a long time.
 def test_decompress_error_parity(value):
     try:
         py_result = decompress(value)

--- a/tests/core/test_libsnappy_compat.py
+++ b/tests/core/test_libsnappy_compat.py
@@ -1,7 +1,12 @@
 from hypothesis import given, settings, strategies as st
 
 from py_snappy import compress, decompress, BaseSnappyError
-from snappy import compress as libsnappy_compress, decompress as libsnappy_decompress, UncompressError
+from snappy import (
+    compress as libsnappy_compress,
+    decompress as libsnappy_decompress,
+    UncompressError,
+)
+
 try:
     from snappy._snappy import CompressedLengthError
 except ImportError:
@@ -30,7 +35,7 @@ def test_libsnappy_decompress_local_compressed(value):
     assert value == result
 
 
-LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError,)
+LIB_SNAPPY_ERRORS = (CompressedLengthError, UncompressError)
 PY_SNAPPY_ERRORS = (BaseSnappyError,)
 
 
@@ -38,10 +43,7 @@ PY_SNAPPY_ERRORS = (BaseSnappyError,)
 # Error cases
 #
 @given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
-@settings(
-    max_examples=1000,
-    deadline=None,  # takes a long time.
-)
+@settings(max_examples=1000, deadline=None)  # takes a long time.
 def test_decompress_error_parity(value):
     try:
         py_result = decompress(value)

--- a/tests/core/test_round_trip.py
+++ b/tests/core/test_round_trip.py
@@ -5,7 +5,7 @@ from py_snappy import compress, decompress
 MEGABYTE = 1000000
 
 
-@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
 @settings(max_examples=10000)
 def test_round_trip(value):
     intermediate = compress(value)

--- a/tests/core/test_round_trip.py
+++ b/tests/core/test_round_trip.py
@@ -5,8 +5,8 @@ from py_snappy import compress, decompress
 MEGABYTE = 1000000
 
 
-@given(value=st.binary(min_size=1, max_size=2 * MEGABYTE))
-@settings(max_examples=1000)
+@given(value=st.binary(min_size=1, max_size=5 * MEGABYTE))
+@settings(max_examples=10000)
 def test_round_trip(value):
     intermediate = compress(value)
     result = decompress(intermediate)


### PR DESCRIPTION
fixes #5 
fixes #7

## What was wrong?

We also want to be sure that `py-snappy` always throws errors on values that `python-snappy` would error out on.

## How was it fixed?

Added hypothesis tests which try to decode random values and ensure that both implementations behave the same.

#### Cute Animal Picture


![squirrel-pumpkin-06](https://user-images.githubusercontent.com/824194/46693159-4700d480-cbc6-11e8-8001-ad42c8d7b973.jpg)
