### PR TITLE
Adjust test vector fixtures to do some fuzzing

### DIFF
--- a/py_snappy/main.py
+++ b/py_snappy/main.py
@@ -214,7 +214,13 @@ C240 = 60 << 2
 C244 = 61 << 2
 C248 = 62 << 2
 C252 = 63 << 2
+
+C8 = 1 << 3
+C64 = 1 << 6
+C256 = 1 << 8
+C2048 = 1 << 11
 C65536 = 1 << 16
+C16777216 = 1 << 24
 C4294967296 = 1 << 32
 
 
@@ -225,14 +231,14 @@ def emit_literal(lit: bytes) -> Iterable[int]:
 
     if n < 60:
         yield (uint8(n) << 2) | TAG_LITERAL
-    elif n < C240:
+    elif n < C256:
         yield C240 | TAG_LITERAL
         yield uint8(n)
-    elif n < C244:
+    elif n < C65536:
         yield C244 | TAG_LITERAL
         yield uint8(n)
         yield uint8(n >> 8)
-    elif n < C65536:
+    elif n < C16777216:
         yield C248 | TAG_LITERAL
         yield uint8(n)
         yield uint8(n >> 8)
@@ -247,12 +253,6 @@ def emit_literal(lit: bytes) -> Iterable[int]:
         raise BaseSnappyError("Source buffer is too long")
 
     yield from lit
-
-
-C8 = 1 << 3
-C64 = 1 << 6
-C256 = 1 << 8
-C2048 = 1 << 11
 
 
 @tuple_gen

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from setuptools import (
 
 extras_require = {
     'test': [
-        "pytest>=3.6.0",
-        "pytest-xdist",
-        "tox>=2.9.1,<3",
-        "hypothesis==3.74.3",
+        "pytest>=5.3.5,<5.4",
+        "pytest-xdist==1.31.0",
+        "tox>=3.14.3,<4",
+        "hypothesis==5.4.1",
         "python-snappy>=0.5.3,<1",
     ],
     'lint': [

--- a/tests/core/test_official_test_vectors.py
+++ b/tests/core/test_official_test_vectors.py
@@ -2,11 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from hypothesis import (
-    given,
-    strategies as st,
-    settings,
-)
+from hypothesis import given, strategies as st, settings
 import py_snappy
 from py_snappy import BaseSnappyError, compress, decompress
 from snappy import (
@@ -47,9 +43,7 @@ FIXTURES_TO_COMPRESS = (
 )
 
 
-fixture_st = st.sampled_from(
-    FIXTURES_TO_COMPRESS,
-).map(load_fixture)
+fixture_st = st.sampled_from(FIXTURES_TO_COMPRESS).map(load_fixture)
 
 
 @st.composite
@@ -60,8 +54,11 @@ def fixture_data(draw, fixture_st=fixture_st):
     return fixture_bytes[slice]
 
 
+MAX_EXAMPLES = 100
+
+
 @given(fixture_data=fixture_data())
-@settings(max_examples=100, deadline=None)  # takes a long time.
+@settings(max_examples=MAX_EXAMPLES, deadline=None)  # takes a long time.
 def test_compression_round_trip_of_official_test_fixtures(fixture_data):
     intermediate = compress(fixture_data)
     actual = decompress(intermediate)
@@ -69,7 +66,7 @@ def test_compression_round_trip_of_official_test_fixtures(fixture_data):
 
 
 @given(fixture_data=fixture_data())
-@settings(max_examples=100, deadline=None)  # takes a long time.
+@settings(max_examples=MAX_EXAMPLES, deadline=None)  # takes a long time.
 def test_decompress_libsnappy_compressed_test_fixture(fixture_data):
     intermediate = libsnappy_compress(fixture_data)
     actual = decompress(intermediate)
@@ -77,7 +74,7 @@ def test_decompress_libsnappy_compressed_test_fixture(fixture_data):
 
 
 @given(fixture_data=fixture_data())
-@settings(max_examples=100, deadline=None)  # takes a long time.
+@settings(max_examples=MAX_EXAMPLES, deadline=None)  # takes a long time.
 def test_libsnapp_decompress_compressed_test_fixture(fixture_data):
     intermediate = compress(fixture_data)
     actual = libsnappy_decompress(intermediate)

--- a/tests/core/test_official_test_vectors.py
+++ b/tests/core/test_official_test_vectors.py
@@ -2,6 +2,11 @@ from pathlib import Path
 
 import pytest
 
+from hypothesis import (
+    given,
+    strategies as st,
+    settings,
+)
 import py_snappy
 from py_snappy import BaseSnappyError, compress, decompress
 from snappy import (
@@ -15,11 +20,16 @@ BASE_DIR = Path(py_snappy.__file__).resolve().parent.parent
 FIXTURES_DIR = BASE_DIR / "tests" / "fixtures"
 
 
+CACHE = {}
+
+
 def load_fixture(fixture_name):
-    fixture_path = FIXTURES_DIR / fixture_name
-    assert fixture_path.exists()
-    assert fixture_path.is_file()
-    return fixture_path.read_bytes()
+    if fixture_name not in CACHE:
+        fixture_path = FIXTURES_DIR / fixture_name
+        assert fixture_path.exists()
+        assert fixture_path.is_file()
+        CACHE[fixture_name] = fixture_path.read_bytes()
+    return CACHE[fixture_name]
 
 
 FIXTURES_TO_COMPRESS = (
@@ -37,25 +47,38 @@ FIXTURES_TO_COMPRESS = (
 )
 
 
-@pytest.mark.parametrize("fixture_name", FIXTURES_TO_COMPRESS)
-def test_compression_round_trip_of_official_test_fixtures(fixture_name):
-    fixture_data = load_fixture(fixture_name)
+fixture_st = st.sampled_from(
+    FIXTURES_TO_COMPRESS,
+).map(load_fixture)
+
+
+@st.composite
+def fixture_data(draw, fixture_st=fixture_st):
+    fixture_bytes = draw(fixture_st)
+    size = len(fixture_bytes)
+    slice = draw(st.slices(size))
+    return fixture_bytes[slice]
+
+
+@given(fixture_data=fixture_data())
+@settings(max_examples=100, deadline=None)  # takes a long time.
+def test_compression_round_trip_of_official_test_fixtures(fixture_data):
     intermediate = compress(fixture_data)
     actual = decompress(intermediate)
     assert fixture_data == actual
 
 
-@pytest.mark.parametrize("fixture_name", FIXTURES_TO_COMPRESS)
-def test_decompress_libsnappy_compressed_test_fixture(fixture_name):
-    fixture_data = load_fixture(fixture_name)
+@given(fixture_data=fixture_data())
+@settings(max_examples=100, deadline=None)  # takes a long time.
+def test_decompress_libsnappy_compressed_test_fixture(fixture_data):
     intermediate = libsnappy_compress(fixture_data)
     actual = decompress(intermediate)
     assert fixture_data == actual
 
 
-@pytest.mark.parametrize("fixture_name", FIXTURES_TO_COMPRESS)
-def test_libsnapp_decompress_compressed_test_fixture(fixture_name):
-    fixture_data = load_fixture(fixture_name)
+@given(fixture_data=fixture_data())
+@settings(max_examples=100, deadline=None)  # takes a long time.
+def test_libsnapp_decompress_compressed_test_fixture(fixture_data):
     intermediate = compress(fixture_data)
     actual = libsnappy_decompress(intermediate)
     assert fixture_data == actual


### PR DESCRIPTION
## What was wrong?

According to https://github.com/ethereum/py-snappy/issues/18 there is a bug hiding in the library.

Rather than blindly make the change I'd like a test vector which demonstrates the failure...

## How was it fixed?

I have not actually been able to produce a failure, however, now the official test vector tests use hypothesis to do the compression/decompression round trips against random subsections of the test vector files.

#### Cute Animal Picture

![enhanced-3598-1397234721-19](https://user-images.githubusercontent.com/824194/73701643-7125b200-46a7-11ea-8049-955df2a4b878.jpg)
