### PR TITLE
Remove setuptools-markdown dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url='https://github.com/ethereum/py-snappy',
     include_package_data=True,
     install_requires=[],
-    setup_requires=[''],
+    setup_requires=[],
     python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['py_snappy'],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url='https://github.com/ethereum/py-snappy',
     include_package_data=True,
     install_requires=[],
-    setup_requires=['setuptools-markdown'],
+    setup_requires=[''],
     python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['py_snappy'],


### PR DESCRIPTION
## What was wrong?

Installation failure of py-snappy due to a non-existent wheel for setuptools-markdown.



## How was it fixed?

According to the pypi page for setuptools-markdown, which links here: https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/ the package is deprecated due to the functionality now being present in setuptools. Just removing the dependency seemed to work fine.


#### Cute Animal Picture


Ummm... why not, here you go!

![put a cute animal picture link inside the parentheses](https://www.comedywildlifephoto.com/images/gallery/0/00001080_p.jpg)
